### PR TITLE
Initializing args if it's undefined to improve compatibility with old browsers

### DIFF
--- a/module.js
+++ b/module.js
@@ -64,7 +64,7 @@
     var module = Module.fetch(namespace);
 
     if (typeof module === 'function') {
-      return module.apply(null, args);
+      return module.apply(null, args || []);
     }
   };
 


### PR DESCRIPTION
For some unknown reason the line "return module.apply(null, args);" doesn't work on the IE8 when args is undefined. Works properly in IE9.

By the way there is already a test that detects this problem in IE8. The test #16 (module.js: runs existing module) fails in IE8. All other tests are passing.
